### PR TITLE
learnblocks: smooth out loading

### DIFF
--- a/docs-learnblocks/index.css
+++ b/docs-learnblocks/index.css
@@ -3,9 +3,10 @@
  */
 
 .learn {
-  overflow: hidden;
   padding: 30px 0;
+  min-height: 380px;
   background-color: var(--color-grey_light);
+  overflow: hidden;
 }
 
 .learn h2 {
@@ -20,11 +21,12 @@
 }
 
 .learnblocks {
-  align-content: space-around;
-  justify-content: center;
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
+  align-content: space-around;
   margin-top: 30px;
+  min-height: 190px;
 }
 
 .learnblocks-item {


### PR DESCRIPTION
Should make visiting the docs a lot more gentle for first-time visitors. Thanks!
## changes
- __learnblocks__: remove reflow when first landing on the home page (non-cached).