### PR TITLE
Return stream to show progress

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -85,7 +85,7 @@ var fontFiles = [
  * Compile CSS
  */
 gulp.task('styles', function() {
-  gulp
+  return gulp
     .src(styleFiles)
     .pipe(concat('build.css'))
     .pipe(myth())
@@ -131,7 +131,7 @@ gulp.task('docs', function() {
  * Copy assets
  */
 gulp.task('assets', function() {
-  gulp
+  return gulp
     .src(imageFiles)
     .pipe(flatten())
     .pipe(gulp.dest(path.join(__dirname, '/build/images')));
@@ -141,7 +141,7 @@ gulp.task('assets', function() {
  * Copy fonts
  */
 gulp.task('fonts', function() {
-  gulp
+  return gulp
     .src(fontFiles)
     .pipe(flatten())
     .pipe(gulp.dest(path.join(__dirname, '/build/fonts')));


### PR DESCRIPTION
This will fix the non responsive feedback while building:

```
➜  docs git:(expand_api) ✗ make build
node_modules/.bin/gulp build
[16:38:54] Using gulpfile ~/dev/wercker/docs/gulpfile.js
[16:38:54] Starting 'docs'...
[16:38:54] Finished 'docs' after 434 ms
[16:38:54] Starting 'modules'...
[16:38:54] Finished 'modules' after 856 μs
[16:38:54] Starting 'styles'...
[16:38:54] Finished 'styles' after 2.19 ms
[16:38:54] Starting 'assets'...
[16:38:54] Finished 'assets' after 2.13 ms
[16:38:54] Starting 'fonts'...
[16:38:54] Finished 'fonts' after 2.05 ms
[16:38:54] Starting 'build'...
[16:38:54] Finished 'build' after 6.44 μs
```
After the `build` it will pause for 20-30 seconds.