### PR TITLE
Please enable TLS/HTTPS for download.wercker.com

### DIFF
--- a/content/docs/cli/installing.md
+++ b/content/docs/cli/installing.md
@@ -7,9 +7,9 @@ tags: cli
 You can obtain both versions for Mac OSX and Linux of the CLI at the
 following locations:
 
-* [Linux 32bit](http://downloads.wercker.com/cli/stable/linux_386/wercker)
-* [Linux 64bit](http://downloads.wercker.com/cli/stable/linux_amd64/wercker)
-* [Mac 64bit](http://downloads.wercker.com/cli/stable/darwin_amd64/wercker)
+* [Linux 32bit](https://downloads.wercker.com/cli/stable/linux_386/wercker)
+* [Linux 64bit](https://downloads.wercker.com/cli/stable/linux_amd64/wercker)
+* [Mac 64bit](https://downloads.wercker.com/cli/stable/darwin_amd64/wercker)
 
 For example downloading the Mac OSX version and
 installing it in `/usr/local/bin` (make sure this directory is available
@@ -17,7 +17,7 @@ in your PATH):
 
 ```sh
 # downloads the Mac OSX CLI to /usr/local/bin (YMMV)
-curl http://downloads.wercker.com/cli/stable/darwin_amd64/wercker -o /usr/local/bin/wercker
+curl https://downloads.wercker.com/cli/stable/darwin_amd64/wercker -o /usr/local/bin/wercker
 ```
 
 And for Linux 64 bit (make sure this directory is available in your
@@ -25,7 +25,7 @@ PATH):
 
 ```sh
 # downloads the Linux CLI to /usr/local/bin (YMMV)
-curl http://downloads.wercker.com/cli/stable/linux_amd64/wercker -o /usr/local/bin/wercker
+curl https://downloads.wercker.com/cli/stable/linux_amd64/wercker -o /usr/local/bin/wercker
 ```
 Next you want to make the CLI executable:
 


### PR DESCRIPTION
It is very very risky business for your users to download binaries over *http*.
Also, you should provide a way to verify the binaries by providing GPG signed SHA-2 checksums.