### PR TITLE
Fix api headers in toc

### DIFF
--- a/content/api/endpoints/index.md
+++ b/content/api/endpoints/index.md
@@ -1,0 +1,3 @@
+### Endpoints
+
+This section explains all the available endpoints and how they can be used.

--- a/content/api/getting-started/index.md
+++ b/content/api/getting-started/index.md
@@ -1,0 +1,7 @@
+### Getting Started
+
+This section contains various code examples showing how the API can be used in various languages. 
+Jump straight to the language of your choice:
+* [golang](http://devcenter.wercker.com/api/getting-started/golang.html)
+* [nodeJS](http://devcenter.wercker.com/api/getting-started/nodejs.html)
+* [python](http://devcenter.wercker.com/api/getting-started/python.html)


### PR DESCRIPTION
When clicking on a header it currently 404's, so added a index.md and some basic content. 
Fixes https://github.com/wercker/docs/issues/184 