### PR TITLE
Fix more broken links

### DIFF
--- a/content/api/index.html
+++ b/content/api/index.html
@@ -87,7 +87,7 @@
           <div class="doc-quicklinks-item">
             <h5>&nbsp;</h5>
             <ul>
-              <li><a href="/docs/services/using-services.html">Using services</a></li>
+              <li><a href="/docs/services/index.html">Using services</a></li>
               <li><a href="/docs/notifications/index.html">Using notifications</a></li>
             </ul>
           </div>

--- a/content/docs/containers/dockerhub.md
+++ b/content/docs/containers/dockerhub.md
@@ -12,6 +12,6 @@ section.
 
 Wercker automatically fetches these containers when your
 pipelines are executed. If you need `service` containers such as
-databases, specify them in the [services](/docs/services/using-services.html) section of your [wercker.yml
+databases, specify them in the [services](/docs/services/index.html) section of your [wercker.yml
 file](/docs/wercker-yml/creating-a-yml.html).
 

--- a/content/docs/containers/private-containers.md
+++ b/content/docs/containers/private-containers.md
@@ -61,5 +61,5 @@ that you either have exported or defined in the
 The domain name for the private registry (in this case `quay.io`)
 is defined before the `username/repo` combination when using a custom registry.
 
-Note that as opposed to the [services](/docs/services/using-services.html) section, which is a list of items,
+Note that as opposed to the [services](/docs/services/index.html) section, which is a list of items,
 the box section contains a singular item and as such is not preceeded by a `-`.

--- a/content/docs/index.html
+++ b/content/docs/index.html
@@ -77,7 +77,7 @@
           <div class="doc-quicklinks-item">
             <h5>&nbsp;</h5>
             <ul>
-              <li><a href="/docs/services/using-services.html">Using services</a></li>
+              <li><a href="/docs/services/index.html">Using services</a></li>
               <li><a href="/docs/notifications/index.html">Using notifications</a></li>
             </ul>
           </div>

--- a/content/error/index.html
+++ b/content/error/index.html
@@ -136,7 +136,7 @@
           <div class="doc-quicklinks-item">
             <h5>&nbsp;</h5>
             <ul>
-              <li><a href="/docs/services/using-services.html">Using services</a></li>
+              <li><a href="/docs/services/index.html">Using services</a></li>
               <li><a href="/docs/notifications/index.html">Using notifications</a></li>
             </ul>
           </div>

--- a/legacy-urls/urlmappings.txt
+++ b/legacy-urls/urlmappings.txt
@@ -4,11 +4,11 @@
 articles/gettingstarted/repositoryaccess.html | http://old-devcenter.wercker.com/articles/gettingstarted/repositoryaccess.html
 articles/gettingstarted/cli.html | http://old-devcenter.wercker.com/articles/gettingstarted/cli.html
 articles/gettingstarted/werckerbot.html | http://old-devcenter.wercker.com/articles/gettingstarted/werckerbot.html
-articles/gettingstarted/web.html | http://old-devcenter.wercker.com/articles/gettingstarted/web.html
+articles/gettingstarted/web.html | /learn/basics/using-the-web-interface.html
 articles/gettingstarted/index.html | http://old-devcenter.wercker.com/articles/gettingstarted/index.html
 articles/werckeryml/validate.html | http://old-devcenter.wercker.com/articles/werckeryml/validate.html
 articles/werckeryml/index.html | http://old-devcenter.wercker.com/articles/werckeryml/index.html
-articles/werckeryml/notifications.html | http://old-devcenter.wercker.com/articles/werckeryml/notifications.html
+articles/werckeryml/notifications.html | /docs/notifications/index.html
 articles/docker/index.html | http://old-devcenter.wercker.com/articles/docker/index.html
 articles/faq/ccmenu.html | http://old-devcenter.wercker.com/articles/faq/ccmenu.html
 articles/faq/whitelist.html | /docs/faq/what-ip-to-whitelist.html


### PR DESCRIPTION
Also redirect some legacy URL's to new devcenter articles (instead of redirecting to the old devcenter)