### PR TITLE
Change bash to no-highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@
 Wercker docs built with [gulp][gulp] and [metalsmith][metalsmith].
 
 ## Install
-```sh
-$ hub clone wercker/docs
+```no-highlight
+hub clone wercker/docs
 ```
+
 Make sure to have [`npm>=2.0.0`][npm] installed to build local modules.
 
 ## Usage

--- a/content/docs/languages/golang.md
+++ b/content/docs/languages/golang.md
@@ -44,7 +44,7 @@ A lint step for go source code that uses
 
 Usage:
 
-```sh
+```yaml
 build:
     steps:
         - golint

--- a/content/docs/languages/python.md
+++ b/content/docs/languages/python.md
@@ -62,7 +62,7 @@ build:
 Many of the docker containers are based on Ubuntu/Debian, you can use the install-package step
 to install additional software. Usage:
 
-```sh
+```yaml
 build:
     steps:
         - install-packages:

--- a/content/docs/services/available-env-vars.md
+++ b/content/docs/services/available-env-vars.md
@@ -14,7 +14,7 @@ container’s environment variables to the current environment.  For example,
 if you want to use [ElasticSearch](http://elasticsearch.com) as a service in
 your application, the following env variables would be injected:
 
-```sh
+```no-highlight
 ELASTICSEARCH_PORT_9200_TCP_PORT=9200
 ELASTICSEARCH_ENV_JAVA_DEBIAN_VERSION=8u40~b22-2
 ELASTICSEARCH_NAME=/wercker-pipeline-xxxxxxxxxxx/elasticsearch
@@ -58,7 +58,7 @@ fmt.Println(“PORT:", os.Getenv("ELASTICSEARCH_PORT_9300_TCP”))
 
 Which would output:
 
-```sh
+```no-highlight
 172.17.1.89
 9300
 ```

--- a/content/docs/services/mariadb.md
+++ b/content/docs/services/mariadb.md
@@ -45,7 +45,7 @@ build:
 Below you can find the environment variables that are created and made available.
 You can use these for connection strings and such in your applications.
 
-```sh
+```no-highlight
 MARIADB_ENV_MARIADB_VERSION=10.0.17+maria-1~wheezy
 MARIADB_PORT=tcp://172.XX.X.XX:3306
 MARIADB_PORT_3306_TCP=tcp://172.X.X.X:3306

--- a/content/docs/services/postgresql.md
+++ b/content/docs/services/postgresql.md
@@ -30,7 +30,7 @@ Now the [`POSTGRES_PASSWORD`] environment variable is set to _ourlittlesecret_ i
 Below you can find the environment variables that are created and made available.
 You can use these for connection strings and such in your applications.
 
-```sh
+```no-highlight
 POSTGRES_PASSWORD: ourlittlesecret
 POSTGRES_PORT=tcp://172.XX.X.XX:5432
 POSTGRES_ENV_POSTGRES_PASSWORD=ourlittlesecret

--- a/content/docs/ssh-keys/using-ssh-keys.md
+++ b/content/docs/ssh-keys/using-ssh-keys.md
@@ -25,7 +25,7 @@ deploy:
 Depending on the container you are using, you may want to use this step so
 builds/deploys don't halt when you setup a connection with them:
 
-```sh
+```no-highlight
 The authenticity of host 'some-server.wercker.com (1.2.3.4)' can't be established.
 RSA key fingerprint is ff:ee:dd:cc:bb:aa:99:88:77:66:55:44:33:22:11:00.
 Are you sure you want to continue connecting (yes/no)?

--- a/content/docs/using-the-cli/installing.md
+++ b/content/docs/using-the-cli/installing.md
@@ -12,28 +12,26 @@ following locations:
 * [Mac 64bit](https://s3.amazonaws.com/downloads.wercker.com/cli/stable/darwin_amd64/wercker)
 
 For example downloading the Mac OSX version and
-installing it in `/usr/local/bin` (make sure this directory is available
-in your PATH):
+installing it in `/usr/local/bin`:
 
-```sh
+```no-highlight
 # downloads the Mac OSX CLI to /usr/local/bin (YMMV)
 curl https://s3.amazonaws.com/downloads.wercker.com/cli/stable/darwin_amd64/wercker -o /usr/local/bin/wercker
 ```
 
-And for Linux 64 bit (make sure this directory is available in your
-PATH):
+And for Linux 64 bit:
 
-```sh
+```no-highlight
 # downloads the Linux CLI to /usr/local/bin (YMMV)
 curl https://s3.amazonaws.com/downloads.wercker.com/cli/stable/linux_amd64/wercker -o /usr/local/bin/wercker
 ```
 Next you want to make the CLI executable:
 
-```sh
+```no-highlight
 chmod +x /usr/local/bin/wercker
 ```
 
 You can use the `wercker version` command to see if a new version of the
 CLI is available. See the [commands section](/docs/using-the-cli/available-commands.html) for more information.
-Some commands require docker to be installed/available, see 
+Some commands require docker to be installed/available, see
 [requirements](/docs/using-the-cli/requirements.html) for more information.

--- a/content/docs/using-the-cli/introspecting-containers.md
+++ b/content/docs/using-the-cli/introspecting-containers.md
@@ -28,7 +28,7 @@ locally](/docs/using-the-cli/local-builds.html) or have
 build artifact as container you can run the following command to inspect
 your container:
 
-```sh
+```no-highlight
 docker run -it --rm build-<BUILD-ID> /bin/bash
 ```
 
@@ -39,7 +39,7 @@ pipeline.
 After you've run the container you can retrieve it's container-id by
 running `docker ps -a`. You can then stop the container:
 
-```sh
+```no-highlight
 docker stop <CONTAINER-ID>
 ```
 

--- a/content/docs/using-the-cli/local-builds.md
+++ b/content/docs/using-the-cli/local-builds.md
@@ -2,7 +2,7 @@
 
 Using the wercker CLI you can build projects locally on your machine.
 
-```sh
+```no-highlight
 wercker build
 ```
 
@@ -11,7 +11,7 @@ wercker build
 You can mount your local project folder directly to the container's
 pipeline path by running:
 
-```sh
+```no-highlight
 wercker build --direct-mount
 ```
 
@@ -20,7 +20,7 @@ wercker build --direct-mount
 By default running `wercker build` will not save the container. In order
 to save the container you must commit it first:
 
-```sh
+```no-highlight
 wercker build --commit
 ```
 

--- a/content/docs/using-the-cli/local-development.md
+++ b/content/docs/using-the-cli/local-development.md
@@ -1,7 +1,7 @@
 ## Local Development with the CLI
 
 You can use the wercker CLI during local development of your
-applications and microservices. 
+applications and microservices.
 
 Similar to the wercker web platform, the
 wercker cli will spin up services in containers alongside the code you
@@ -13,9 +13,9 @@ changes _before_ you commit them.
 
 The `wercker dev` command executes the `dev` pipeline designed for live
 development. Whereas the wercker [build command](/docs/using-the-cli/local-builds.html) a copy of your code
-is built inside a container in order to mitigate side effects, 
+is built inside a container in order to mitigate side effects,
 the `dev` command directly mounts your local directory inside the
-container. 
+container.
 
 ### internal/watch
 
@@ -38,7 +38,7 @@ dev:
 
 In this example we set up a `dev` pipeline in which one initial step,
 `npm-install` is run to prepare the container's environment and install
-the necessary dependencies. 
+the necessary dependencies.
 
 Next, we use the `internal/watch` step to
 launch the application and through `reload: true` we reload the
@@ -46,7 +46,7 @@ environment on file changes.
 
 We run the development pipeline as follows:
 
-```sh
+```no-highlight
 wercker dev --publish 5000
 ```
 
@@ -60,7 +60,7 @@ but we tell you the IP address of the host once the step is run.
 Often times you want to inspect the state of a container between steps
 or tweak services running inside a container. The `internal/shell` step
 drops you into a shell of the running container and enables to you to
-look around and tweak things. 
+look around and tweak things.
 
 As with the `internal/watch` step,
 `internal/shell` goes hand in hand with the `dev pipeline`.
@@ -89,7 +89,7 @@ container. This flag is great for debugging and inspect the environment.
 
 You can use it as follows:
 
-```sh
+```no-highlight
 wercker dev --publish 5000 --attach-on-error
 ```
 
@@ -101,4 +101,4 @@ these sample applications.
  * [python](https://github.com/wercker/getting-started-python)
  * [ruby](https://github.com/wercker/getting-started-ruby)
 
-     
+

--- a/content/docs/using-the-cli/pulling-containers.md
+++ b/content/docs/using-the-cli/pulling-containers.md
@@ -20,19 +20,19 @@ page for an application you can filter based on branch.
 
 Here are some examples of pulling a build by application:
 
-```bash
+```no-highlight
 wercker pull <NAME>/<APPLICATION> --branch <BRANCH> --load
 ```
 
 Or the last passed build:
 
-```bash
+```no-highlight
 wercker pull <NAME>/<APPLICATION> --branch <BRANCH> --result passed --load
 ```
 
 Pulling using a build-id is the shortest:
 
-```bash
+```no-highlight
 wercker pull <BUILD-ID> --load
 ```
 
@@ -75,7 +75,7 @@ either delete the file, or use the `-f` flag (`force`) and rerun the `wercker pu
 
 Check out the all available flags in the help page:
 
-```sh
+```no-highlight
 wercker pull --help
 ```
 

--- a/content/docs/using-the-cli/requirements.md
+++ b/content/docs/using-the-cli/requirements.md
@@ -25,7 +25,7 @@ If you're eager to get up to speed on OSX, below is a quickstart that
 installs boot2docker via the [homebrew package
 manager](http://brew.sh/).
 
-```sh
+```no-highlight
 brew install boot2docker
 
 boot2docker init
@@ -39,7 +39,7 @@ $(boot2docker shellinit)
 Under the hood the `shellinit` command configures the Docker certificates
 and environment variables, which actually distills to:
 
-```sh
+```no-highlight
 export DOCKER_HOST=tcp://192.168.59.103:2376
 export DOCKER_CERT_PATH=$HOME/.boot2docker/certs/boot2docker-vm
 export DOCKER_TLS_VERIFY=1

--- a/content/learn/basics/the-wercker-cli.md
+++ b/content/learn/basics/the-wercker-cli.md
@@ -30,7 +30,7 @@ If you're eager to get up to speed on OSX, below is a quickstart that
 installs boot2docker via the [homebrew package
 manager](http://brew.sh/).
 
-```sh
+```no-highlight
 brew install boot2docker
 
 boot2docker init
@@ -52,7 +52,7 @@ For example downloading the Mac OSX version and
 installing it in `/usr/local/bin` (make sure this directory is available
 in your PATH):
 
-```sh
+```no-highlight
 # downloads the Mac OSX CLI to /usr/local/bin (YMMV)
 curl https://s3.amazonaws.com/downloads.wercker.com/cli/stable/darwin_amd64/wercker -o /usr/local/bin/wercker
 ```
@@ -60,7 +60,7 @@ curl https://s3.amazonaws.com/downloads.wercker.com/cli/stable/darwin_amd64/werc
 And for Linux 64 bit (make sure this directory is available in your
 PATH):
 
-```sh
+```no-highlight
 # downloads the Linux CLI to /usr/local/bin (YMMV)
 curl https://s3.amazonaws.com/downloads.wercker.com/cli/stable/linux_amd64/wercker -o /usr/local/bin/wercker
 ```
@@ -70,7 +70,7 @@ in your PATH
 
 Next you want to make the CLI executable:
 
-```sh
+```no-highlight
 chmod +x /usr/local/bin/wercker
 ```
 
@@ -78,7 +78,7 @@ chmod +x /usr/local/bin/wercker
 
 You can log into wercker with your username and password as follows:
 
-```sh
+```no-highlight
 wercker login
 ```
 

--- a/content/learn/build/introspecting-builds.md
+++ b/content/learn/build/introspecting-builds.md
@@ -1,18 +1,18 @@
 ## Introspecting builds
 
 Before you can introspect your build you need to load it into Docker. You can
-either do this by adding the `--load` flag to the `wercker pull` command. 
+either do this by adding the `--load` flag to the `wercker pull` command.
 
 Otherwise you need to use the docker command to load the container into Docker:
 
-```sh
+```no-highlight
 docker load -i <path>
 ```
 
 Now that the container is loaded into Docker, you can use the standard Docker
 tool to execute commands on it.
 
-```sh
+```no-highlight
 docker run -it --rm build-<build-id> /bin/bash
 ```
 

--- a/content/learn/build/local-builds.md
+++ b/content/learn/build/local-builds.md
@@ -8,7 +8,7 @@ setting up your local wercker environment.
 
 From within your project folder run the following command.
 
-```sh
+```no-highlight
 wercker build
 ```
 

--- a/content/learn/build/pulling-builds.md
+++ b/content/learn/build/pulling-builds.md
@@ -12,7 +12,7 @@ In order to pull a build you need a `build-id` and of course the right
 permissions to a project. You can pull builds with the following
 command:
 
-```sh
+```no-highlight
 wercker pull build-id
 ```
 
@@ -20,13 +20,13 @@ You can also query for a certain build. In order to do this, you need the name
 of the owner and project-name on wercker. Then you can optionally give some
 extra queries such as branch or result.
 
-```sh
+```no-highlight
 wercker pull owner/project-name [query flags]
 ```
 
 Checkout the all available flags in the help page:
 
-```sh
+```no-highlight
 wercker pull --help
 ```
 

--- a/content/quickstarts/deployment/heroku.md
+++ b/content/quickstarts/deployment/heroku.md
@@ -24,7 +24,7 @@ A sample application is already available on
 [GitHub](https://github.com/wercker/wercker-nodejs-heroku) which you can
 clone or fork.
 
-```sh
+```no-highlight
 git clone https://github.com/wercker/wercker-nodejs-heroku.git
 ```
 
@@ -52,8 +52,8 @@ detect most common programming languages and generate sensible defaults.
 In the root of the folder containing the source files run the following
 command:
 
-```sh
-❯ wercker detect
+```no-highlight
+$ wercker detect
 ########### Detecting your project! #############
 Detected: nodejs
 Generating wercker.yml
@@ -105,14 +105,14 @@ steps in [this section](/docs/steps/index.html).
 
 Add and commit your `wercker.yml` file to your git repository:
 
-```sh
+```no-highlight
 git add wercker.yml
 git commit -m 'added wercker.yml'
 ```
 
 Now push it to GitHub:
 
-```sh
+```no-highlight
 git push origin master
 ```
 
@@ -129,7 +129,7 @@ We are now ready to start deploying to Heroku. First, let's add a
 to start for your application. Create this file with the following
 contents and add it to your repository.
 
-```sh
+```no-highlight
 web: node app.js
 ```
 
@@ -198,8 +198,8 @@ Now, we're all set to deploy!
 
 Let's commit and check in our final changes to the `wercker.yml` file.
 
-```sh
-git commit -am 'added deploy section to wercker.yml
+```no-highlight
+git commit -am 'added deploy section to wercker.yml'
 ```
 
 Now when we do a `git push origin master` this will trigger a build on

--- a/legacy-docs/boxes/bash.md
+++ b/legacy-docs/boxes/bash.md
@@ -106,7 +106,7 @@ Make sure to add your repository to wercker. If you need some guidance with this
 
 Add your wercker-box.yml to your git repository and push it to either GitHub or Bitbucket.
 
-``` bash
+```no-highlight
 git add wercker-box.yml
 git commit -am 'added wercker-box.yml'
 git push origin master

--- a/legacy-docs/boxes/chef.md
+++ b/legacy-docs/boxes/chef.md
@@ -169,7 +169,7 @@ Make sure to add your repository to wercker. If you need some guidance with this
 
 Add your wercker-box.yml to your git repository and push it to either GitHub or Bitbucket.
 
-``` bash
+```no-highlight
 git add wercker-box.yml
 git commit -am 'added wercker-box.yml'
 git push origin master

--- a/legacy-docs/boxes/puppet.md
+++ b/legacy-docs/boxes/puppet.md
@@ -137,7 +137,7 @@ Make sure to add your repository to wercker. If you need some guidance with this
 
 Add your wercker-box.yml to your git repository and push it to either GitHub or Bitbucket.
 
-```bash
+```no-highlight
 git add .
 git commit -am 'added wercker-box.yml and others'
 git push origin master

--- a/legacy-docs/cli/installation.md
+++ b/legacy-docs/cli/installation.md
@@ -31,15 +31,15 @@ For Windows we recommend installing [Cygwin](http://www.cygwin.com/) with the fo
 * web/wget
 
 Next, download and install `easy_install` with the following commands
-```bash
-$ wget http://peak.telecommunity.com/dist/ez_setup.py
-$ python ez_setup.py
+```no-highlight
+wget http://peak.telecommunity.com/dist/ez_setup.py
+python ez_setup.py
 ```
 
 We will now install `pip` through easy_install:
 
-```bash
-$ easy_install pip
+```no-highlight
+easy_install pip
 ```
 
 After which you can continue to install the `wercker` command line interface.
@@ -48,8 +48,8 @@ After which you can continue to install the `wercker` command line interface.
 
 The wercker command line interface is written in python and on Linux/Mac OSX can be installed by running:
 
-```bash
-$ pip install wercker
+```no-highlight
+pip install wercker
 ```
 
 Depending on your operating system, you may have to run this with superuser privileges (i.e. use `sudo pip install wercker`). Also note:

--- a/legacy-docs/deployment/jekylls3.md
+++ b/legacy-docs/deployment/jekylls3.md
@@ -51,10 +51,10 @@ The second line describes the `build` section that consists of steps, in this ca
 
 After you created the `wercker.yml` add it to your repository by executing the following commands.
 
-```bash
-    git add wercker.yml
-    git commit -m 'Add wercker.yml'
-    git push origin master
+```no-highlight
+git add wercker.yml
+git commit -m 'Add wercker.yml'
+git push origin master
 ```
 </br>
 
@@ -97,10 +97,10 @@ We could also _hard code_ the key and key secret in here, but that is not someth
 
 Commit the changes of the `wercker.yml` file and push them to your repository.
 
-```bash
-    git add wercker.yml
-    git commit -m 'Add deployment section'
-    git push origin master
+```no-highlight
+git add wercker.yml
+git commit -m 'Add deployment section'
+git push origin master
 ```
 </br>
 

--- a/legacy-docs/deployment/middleman.md
+++ b/legacy-docs/deployment/middleman.md
@@ -13,7 +13,7 @@
 
 As said we'll be using the Middleman blogging extension, so make sure you *gem install* it.
 
-```bash
+```no-highlight
 middleman init --template blog
 
 git init
@@ -70,7 +70,7 @@ The `s3sync` step synchronises a source directory with an Amazon S3 bucket. The 
 
 After you've created the `wercker.yml` add it to your repository by executing the following commands in your terminal.
 
-```bash
+```no-highlight
 git add wercker.yml
 git commit -m 'Add wercker.yml'
 git push origin master

--- a/legacy-docs/getting-started/cli.md
+++ b/legacy-docs/getting-started/cli.md
@@ -23,7 +23,7 @@ The first step is to fork one of the above mentioned repositories and clone it t
 
 Go to the repository on your machine and run `wercker create`. This should result in an output similar to this:
 
-``` bash
+```no-highlight
 $ wercker create
 -----------------------
 welcome to wercker-cli
@@ -49,7 +49,7 @@ Make your choice (1=default):
 
 The wercker create wizard will pause here, to allow you to catch up with what it is about to do. Since my repository has only one remote location (GitHub), pressing enter or input 1 will suffice. After which the wizard will continue:
 
-```bash
+```no-highlight
 github repository detected...
 Selected repository url is git@github.com:wercker/USERNAME/REPOSITORY.git
 
@@ -103,7 +103,7 @@ Note: wercker will check if you have configured repository access correctly. For
 
 This all that's needed to add a application to wercker. But there are some handy commands we can do while we are waiting for the build to complete (or go to the website). The first one is `wercker queue`, which lists all jobs that still need to be done for this application. This can be both builds as well as deploys.
 
-``` bash
+```no-highlight
 $ wercker queue
 -----------------------
 welcome to wercker-cli
@@ -126,7 +126,7 @@ No deploy targets found.
 
 The second command is `wercker builds` which lists the 5 latest builds (including both finished and unfinished ones).
 
-``` bash
+```no-highlight
 $ wercker builds
 -----------------------
 welcome to wercker-cli
@@ -154,7 +154,7 @@ You are now ready to deploy this application to the Cloud. For this guide we wil
 
 We first create a new app on heroku, by running `heroku create`
 
-``` bash
+```no-highlight
 $ heroku create
 Creating secret-bastion-2817... done, region is us
 http://secret-bastion-2817.herokuapp.com/ | git@heroku.com:secret-bastion-2817.git
@@ -163,8 +163,9 @@ Git remote heroku added
 
 Add the wercker addon to your new heroku application and run `wercker targets add`
 
-```bash
+```no-highlight
 $ heroku addons:add wercker
+
 Adding wercker on secret-bastion-2817... done, v2 (free)
 Use `heroku addons:open wercker` to get started.
 Use `heroku addons:docs wercker` to view documentation.

--- a/legacy-docs/getting-started/wercker-bot.md
+++ b/legacy-docs/getting-started/wercker-bot.md
@@ -25,7 +25,7 @@ flow as seen below:
 When adding a project through the [command line
 interface](/articles/cli/) you are also made aware of this:
 
-```bash
+```no-highlight
 github repository detected...
 Selected repository url is
 git@github.com:flenter/getting-started-python.git

--- a/legacy-docs/language-guides/go/deploying-go-apps-to-heroku.md
+++ b/legacy-docs/language-guides/go/deploying-go-apps-to-heroku.md
@@ -86,13 +86,13 @@ Now you can actually open the wercker add-on page, `heroku addons:open wercker` 
 
 First open the wercker add-on page on Heroku:
 
-``` bash
+```no-highlight
 heroku addons:open wercker
 ```
 
 and then create your app on wercker:
 
-``` bash
+```no-highlight
 wercker create
 ```
 

--- a/legacy-docs/language-guides/go/getting-started-go.md
+++ b/legacy-docs/language-guides/go/getting-started-go.md
@@ -97,7 +97,7 @@ This unittest uses the [httptest librariy](http://golang.org/pkg/net/http/httpte
 
 Now push this code to GitHub or Bitbucket:
 
-``` bash
+```no-highlight
 git init
 git add .
 git commit -am 'init'
@@ -125,7 +125,7 @@ These items are sufficient to test and build our application, so we do not need 
 
 Add the **wercker.yml** file to your git repository and push it.
 
-``` bash
+```no-highlight
 git add wercker.yml
 git commit -am 'added wercker.yml'
 git push origin master

--- a/legacy-docs/language-guides/nodejs/tdd-with-mongoose.md
+++ b/legacy-docs/language-guides/nodejs/tdd-with-mongoose.md
@@ -213,7 +213,7 @@ We have previously defined a `dev`, `test` and `production` setting in our appli
 
 After you've finished adding your application, we are ready to push our repository.
 
-``` bash
+```no-highlight
 git add .
 git commit -am 'init'
 git push origin master
@@ -227,8 +227,8 @@ This will trigger a build on wercker which looks like this:
 
 We will deploy our application to Heroku, so make sure you have a (verified) [Heroku](http://heroku.com) account and have installed the [Heroku Toolbelt](http://toolbelt.heroku.com). Let's first create an app:
 
-``` bash
-heroku create
+```no-highlight
+$ heroku create
 
 Creating guarded-atoll-9149... done, stack is cedar
 http://guarded-atoll-9149.herokuapp.com/ | git@heroku.com:guarded-atoll-9149.git
@@ -236,8 +236,8 @@ Git remote heroku added
 ```
 Now we need a MongoDB instance in the cloud! Fortunately, Heroku has a Marketplace (wercker is [on it](http://addons.heroku.com/wercker) by the way) filled with addons. One of which are our friends at [Mongolab](http://mongolab.com), so let's use their [add-on](https://addons.heroku.com/mongolab) to [provision](https://devcenter.heroku.com/articles/mongolab) a MongoDB database:
 
-``` bash
-heroku addons:add mongolab
+```no-highlight
+$ heroku addons:add mongolab
 
 Adding mongolab on guarded-atoll-9149... done, v3 (free)
 Welcome to MongoLab.  Your new subscription is ready for use.  Please consult the MongoLab Add-on Admin UI for more information and useful management tools.
@@ -246,7 +246,7 @@ Use `heroku addons:docs mongolab` to view documentation.
 
 For our `test` environment we used the `WERCKER_MONGODB_HOST` environment variable that was provided by wercker and was defined through the `wercker.yml`. We now need a similar environment variable for our production setting which is powered by Heroku and Mongolab. We can retrieve this environment variable, again via the Heroku command line interface:
 
-``` bash
+```no-highlight
 heroku config | grep MONGOLAB_URI
 
 MONGOLAB_URI: mongodb://heroku_app3489u7438034:ofs0gfjfsdgsdfdsgfobfsd345ffsd3ej738@dfsdf45fsd628.mongolab.com:31628/heroku_app16434933244
@@ -271,7 +271,7 @@ app.configure('production', function() {
 
 Similarly to adding the `NODE_ENV=test` environment variable to wercker in the previous post, we need to do the same for Heroku, but now of course `NODE_ENV=production` as Heroku is our production environment.
 
-``` bash
+```no-highlight
 heroku config:set NODE_ENV=production
 
 Setting config vars and restarting guarded-atoll-9149... done, v6
@@ -291,7 +291,7 @@ web: node app.js
 
 Let's add this file to our repository and push it to our version control system:
 
-``` bash
+```no-highlight
 git add Procfile
 git commit -am 'added Procfile'
 git push origin master

--- a/legacy-docs/language-guides/php/gettingstarted-php.md
+++ b/legacy-docs/language-guides/php/gettingstarted-php.md
@@ -18,10 +18,10 @@ test and build pipeline setup at wercker.
 
 Start by creating a new git repository on your local machine. This will be the place where we store all the application source files.
 
-``` bash
-$ mkdir php-cities
-$ cd php-cities
-$ git init
+```no-highlight
+mkdir php-cities
+cd php-cities
+git init
 ```
 
 ## Adding index.php
@@ -42,17 +42,17 @@ echo json_encode($cities, JSON_PRETTY_PRINT);
 
 Add the `index.php` file to the git repository.
 
-``` bash
-$ git add index.php
-$ git commit -m 'Adds index.php'
+```no-highlight
+git add index.php
+git commit -m 'Adds index.php'
 ```
 
 ## Running the service
 
 See the service in action by serving it with the built-in webserver that PHP offers since version 5.4.
 
-``` bash
-$ php -S localhost:8000
+```no-highlight
+php -S localhost:8000
 ```
 
 Open your favorite browser and browse to [localhost:8000](http://localhost:8000) to see your service in action.
@@ -84,9 +84,9 @@ build:
 
 Add the file to your git repository:
 
-``` bash
-$ git add wercker.yml
-$ git commit -m 'Adds wercker.yml that defines the build'
+```no-highlight
+git add wercker.yml
+git commit -m 'Adds wercker.yml that defines the build'
 ```
 
 ## Add project to wercker
@@ -103,9 +103,9 @@ This is very useful for future development and allows you to notice breaking cha
 
 If you do not have PHPUnit installed, do so now via pear:
 
-``` bash
-$ pear config-set auto_discover 1
-$ pear install pear.phpunit.de/PHPUnit
+```no-highlight
+pear config-set auto_discover 1
+pear install pear.phpunit.de/PHPUnit
 ```
 
 See the [installing PHPUnit](http://phpunit.de/manual/3.7/en/installation.html) for more ways to install PHPUnit.
@@ -134,9 +134,9 @@ class CitiesResponseTest extends PHPUnit_Framework_TestCase
 
  Add this test to the git repository.
 
-``` bash
-$ git add tests/ResponseTest.php
-$ git commit -m 'Adds integration test'
+```no-highlight
+git add tests/ResponseTest.php
+git commit -m 'Adds integration test'
 ```
 
 ## Setup PHPUnit
@@ -170,10 +170,10 @@ as follows:
 
 Add this test to the git repository:
 
-``` bash
-$ git add bootstrap.php
-$ git add phpunit.xml
-$ git commit -m 'Adds phpunit setup files'
+```no-highlight
+git add bootstrap.php
+git add phpunit.xml
+git commit -m 'Adds phpunit setup files'
 ```
 
 ## Add httpful dependency
@@ -192,29 +192,29 @@ following contents:
 
 Now install the dependencies by executing the following command.
 
-``` bash
-$ composer install
+```no-highlight
+composer install
 ```
 
 Add the `composer.json` and the `composer.lock` file that was just created by composer to the repository.
 
-``` bash
-$ git add composer.json
-$ git add composer.lock
-$ git commit -m 'Adds composer depedency files'
+```no-highlight
+git add composer.json
+git add composer.lock
+git commit -m 'Adds composer depedency files'
 ```
 
 ## Run PHPUnit
 
 Start a new terminal window that hosts the service.
 
-``` bash
-$ php -S localhost:8000
+```no-highlight
+php -S localhost:8000
 ```
 
 In the other window, run php unit and see the test pass.
 
-``` bash
+```no-highlight
 $ phpunit
 PHPUnit 3.7.21 by Sebastian Bergmann.
 
@@ -255,9 +255,9 @@ commits should trigger a build on wercker. The build consists of a step
 that installs the dependencies defined in `composer.json`, serves the
 application with PHP's built-in webserver and then executes the integration test.
 
-``` bash
-$ git add wercker.yml
-$ git push origin master
+```no-highlight
+git add wercker.yml
+git push origin master
 ```
 
 Now go to your application at [wercker](http://app.wercker.com) and see your build succeed.

--- a/legacy-docs/language-guides/python/django-postgres.md
+++ b/legacy-docs/language-guides/python/django-postgres.md
@@ -27,39 +27,41 @@ You can find the code for this tutorial on [Github](https://github.com/mies/werc
 
 First we set up a virtual environment for our application:
 
-``` bash
-  $ virtualenv venv --distribute
-  New python executable in venv/bin/python
-  Installing distribute...............done.
-  Installing pip...............done.
+```no-highlight
+$ virtualenv venv --distribute
+New python executable in venv/bin/python
+Installing distribute...............done.
+Installing pip...............done.
 ```
 
 And now activate your newly created environment:
 
-``` bash
-  $ source venv/bin/activate
+```no-highlight
+source venv/bin/activate
 ```
 
 ## Declare dependencies
 
 For this application we install django, the python postgres driver and Kenneth Reitz's excellent [dj-database-url](https://github.com/kennethreitz/dj-database-url) module
 
-``` bash
-$ pip install django psycopg2 dj-database-url
+```no-highlight
+pip install django psycopg2 dj-database-url
 ```
 
 Now go to the empty repository and define our dependencies in a requirements.txt file
 
-    django
-    psycopg2
-    dj-database-url
+```no-highlight
+django
+psycopg2
+dj-database-url
+```
 
 
 ## Create base structure
 We can now create our django project, by running django-admin.py.
 
-``` bash
-$ django-admin.py startproject wercks .
+```no-highlight
+django-admin.py startproject wercks .
 ```
 
 ## Update your settings.py
@@ -82,8 +84,8 @@ DATABASES = {
 
 Let's add a simple demo app:
 
-``` bash
-$ python manage.py startapp wercksdemo
+```no-highlight
+python manage.py startapp wercksdemo
 ```
 
 And append it to the INSTALLED_APPS list in the wercks/settings.py, resulting in:
@@ -185,10 +187,10 @@ class HomeTest(TestCase):
 
 ## Push your changes
 
-``` bash
-$ git add .
-$ git commit -am 'init'
-$ git push origin master
+```no-highlight
+git add .
+git commit -am 'init'
+git push origin master
 ```
 
 ## Add repository to wercker

--- a/legacy-docs/language-guides/python/flask.md
+++ b/legacy-docs/language-guides/python/flask.md
@@ -155,10 +155,10 @@ From the wercker dashboard select the deployment tab and create a Heroku deploy 
 
 ## Push your code to GitHub
 
-```bash
-$ git add .
-$ git commit -m 'init'
-$ git push origin master
+```no-highlight
+git add .
+git commit -m 'init'
+git push origin master
 ```
 
 As you have previously added this repository to wercker, your push gets automatically picked up and triggers a build.

--- a/legacy-docs/language-guides/python/flaskredis.md
+++ b/legacy-docs/language-guides/python/flaskredis.md
@@ -19,23 +19,23 @@ You can see the final result of this application on my [wercker page](https://ap
 
 We *highly* recommend using [virtualenv](http://www.virtualenv.org/) and [pip](http://www.pip-installer.org/) to islolate your python environment, so lets do that. In your project folder run the following commands:
 
-``` bash
-$ virtualenv venv --distribute
-$ source venv/bin/activate
+```no-highlight
+virtualenv venv --distribute
+source venv/bin/activate
 ```
 
 This creates a virtual environment folder called 'venv' and activates the Python executable therein.
 
 Next lets install our dependencies. In this case we need Flask and the [Python Redis interface](https://github.com/andymccurdy/redis-py):
 
-``` bash
-$ pip install flask
-$ pip install redis
+```no-highlight
+pip install flask
+pip install redis
 ```
 We want to save our requirements.txt file for our environment for reuse. Wercker also needs this file of course to run our test that we'll create later.
 
-``` bash
-$ pip freeze > requirements.txt
+```no-highlight
+pip freeze > requirements.txt
 ```
 
 Our environment is set up, so lets get started building our API.
@@ -142,10 +142,10 @@ Finally, you can see the `build` section, which contains two steps. First, the `
 
 Now that we have created all the files we need, lets push this our to our version control system:
 
-``` bash
-$ git add .
-$ git commit -am 'initial commit'
-$ git push origin master
+```no-highlight
+git add .
+git commit -am 'initial commit'
+git push origin master
 ```
 Now lets get started with wercker!
 
@@ -157,8 +157,8 @@ After you have signed up, make sure you connect either your GitHub or Bitbucket 
 
 The command line interface can be installed by running:
 
-``` bash
-$ pip install wercker
+```no-highlight
+pip install wercker
 ```
 
 If you want to frequently use the CLI it is a good idea to install it outside of your 'virtual environment', otherwise it would only be available there.
@@ -166,14 +166,14 @@ If you want to frequently use the CLI it is a good idea to install it outside of
 
 Next we run:
 
-``` bash
-$ wercker login
+```no-highlight
+wercker login
 ```
 
 This is only needed once and will ask you for your wercker username and password. Next we are ready to add our repository by running:
 
-``` bash
-$ wercker create
+```no-highlight
+wercker create
 ```
 
 This command will do some introspection and see if it can find a git repository. It will also check to see if the user, `werckerbot` has access to the repository on GitHub or Bitbucket in order to run your builds. Make sure this is the case, and then go to your application page on wercker. A build has been triggered and you should see it running.

--- a/legacy-docs/language-guides/ruby/rails-mongoid.md
+++ b/legacy-docs/language-guides/ruby/rails-mongoid.md
@@ -22,7 +22,7 @@ You can find the code for this tutorial on [Github](https://github.com/mies/mong
 
 We will start out with a fresh rails project but will will not utilize Active Record as we're using MongoDB for our database. If you would like to use MySQL or Postgres alongside MongoDB you should not add the `--skip-active-record` option.
 
-``` bash
+```no-highlight
 rails new mongodb-demo --skip-active-record
 ```
 
@@ -37,7 +37,7 @@ gem 'mongoid'
 ```
 Now we are ready to bundle our gems.
 
-``` bash
+```no-highlight
 bundle install
 ```
 
@@ -47,13 +47,13 @@ We have to let our Rails app know it should use MongoDB, so lets create a config
 
 Generate a `mongoid.yml` file
 
-``` bash
+```no-highlight
 rails g mongoid:config
 ```
 
 and update the `test` section with the wercker [environment variable](/articles/available-services):
 
-``` bash
+```yaml
 test:
   sessions:
     default:
@@ -86,7 +86,7 @@ The `services` section specifies any database you want to leverage, in this case
 
 ## Push to GitHub
 
-``` bash
+```no-highlight
 git add .
 git commit -am 'init'
 git push origin master

--- a/legacy-docs/language-guides/ruby/settingup-rails4.md
+++ b/legacy-docs/language-guides/ruby/settingup-rails4.md
@@ -28,13 +28,13 @@ We will use the wercker command line interface
 
 First, make sure you have Rails4 installed on your machine. Check out the announcement for more info, but the gist of it is:
 
-``` bash
+```no-highlight
 gem install rails --version 4.0.0 --no-ri --no-rdoc
 ```
 
 Next let's create a new application:
 
-``` bash
+```no-highlight
 rails new getting-started-rails4
 ```
 
@@ -62,9 +62,10 @@ gem 'pg'
 
 We want to deploy to [Heroku](http://heroku.com), so first create a `Procfile`:
 
-``` bash
+```no-highlight
 web: bundle exec unicorn -p $PORT -c ./config/unicorn.rb
 ```
+
 We're using the [unicorn](http://unicorn.bogomips.org/) application server so let's create a configuration file for it in the `config` folder:
 
 ``` ruby
@@ -95,7 +96,7 @@ end
 
 Next we create a Heroku application:
 
-``` bash
+```no-highlight
 heroku create
 
 Creating powerful-badlands-2653... done, stack is cedar
@@ -129,20 +130,20 @@ Commit and push your changes to [GitHub](http://github.com) or [Bitbucket](http:
 
 You can now either add your application to wercker via the [command line interface](http://devcenter.wercker.com/articles/gettingstarted/cli.html) or via the [web ui](http://devcenter.wercker.com/articles/gettingstarted/web.html). We will be using the [CLI](http://devcenter.wercker.com/articles/cli/) which is a Python application that you can install via:
 
-``` bash
+```no-highlight
 pip install wercker
 ```
 
 No we add our app to wercker by running:
 
-``` bash
+```no-highlight
 wercker create
 ```
 
 That will not only add our application to wercker but also automatically set up our Heroku deploy target and trigger a build!
 Let's view our application on wercker by running (or just visit the web interface)
 
-``` bash
+```no-highlight
 wercker open
 ```
 You should now see your green build!
@@ -153,13 +154,13 @@ You should now see your green build!
 
 Finally, running the following command will deploy your application to Heroku:
 
-``` bash
+```no-highlight
 wercker deploy
 ```
 
 This command will ask you which build you want to deploy to which target (we just have one on Heroku) and presents the following output:
 
-```bash
+```no-highlight
 -----------------------
 welcome to wercker-cli
 -----------------------

--- a/legacy-docs/steps/create.md
+++ b/legacy-docs/steps/create.md
@@ -74,7 +74,7 @@ Make sure to add your repository to wercker. If you need some guidance with this
 
 Add your **wercker-step.yml** and **run.sh** to your git repository and push it to either GitHub or Bitbucket.
 
-```bash
+```no-highlight
 git add wercker-step.yml run.sh
 git commit -am 'added wercker-step.yml and run.sh'
 git push origin master

--- a/legacy-docs/steps/guide.md
+++ b/legacy-docs/steps/guide.md
@@ -195,9 +195,8 @@ A step should not depend on content of the cache and should be able to handle sc
 
 Here is a simple example of a step that leverages the cache:
 
-``` bash
-if [ -f "$WERCKER_CACHE_DIR/mystep/a-dependency.bin" ];
-then
+```bash
+if [ -f "$WERCKER_CACHE_DIR/mystep/a-dependency.bin" ]; then
     debug "a-dependency.bin found in cache"
 else
     debug "tool.rar not found in cache, will download"


### PR DESCRIPTION
This changes all command line invocation examples from `bash` or `sh` to `no-highlight`. Because command line commands are not the same as bash scripts (which `bash` is meant for)

I propose the following:
- Always use `no-highlight` for code blocks that involve command line commands
- When showing command(s), without the output: Never prepend the commands with `$` or something similar. (helps with copy/paste)
- When showing command(s), with output: Prepend with `$`. (Helps to distinguish command from output)