### PR TITLE
Update heroku.md key-name env var instructions

### DIFF
--- a/content/quickstarts/deployment/heroku.md
+++ b/content/quickstarts/deployment/heroku.md
@@ -244,14 +244,15 @@ deploy:
   steps:
     - heroku-deploy:
         key: $HEROKU_KEY
-        key-name: $HEROKU_KEY_PAIR
+        key-name: HEROKU_KEY_PAIR
         user: $HEROKU_USER
         app-name: $HEROKU_APP_NAME
 ```
 
+Note: You should not prefix the `key-name` environment variable with a dollar 
+sign (`$`) or postfix it with `_PRIVATE` or `_PUBLIC`.
 
 ![image](/images/heroku_08.jpg)
 
 And your all done! Now when deploying via wercker, you no longer receive
 an email that a new SSH key was added!
-


### PR DESCRIPTION
Make it clear that the environment variable used for `app-name` should not be prefixed with a `$` unlike the other variables, as defined here: https://github.com/wercker/step-heroku-deploy