### PR TITLE
instructions on using docker machine

### DIFF
--- a/content/learn/basics/the-wercker-cli.md
+++ b/content/learn/basics/the-wercker-cli.md
@@ -17,27 +17,38 @@ depending on your distribution and package manager. See Docker's
 [installation
 instructions](https://docs.docker.com/installation/#installation) fore more information.
 
-If you are running Mac OSX you can install Docker using an installer
-called [boot2docker](https://docs.docker.com/installation/mac/) that
-will install [VirtualBox](https://www.virtualbox.org/) and a minimal
-Docker environment. As an alternative, you can use
-[Vagrant](http://vagrantup.com) to install a separate boot2docker
-virtual machine using [this vagrant box](https://github.com/mitchellh/boot2docker-vagrant-box).
+If you are running Mac OSX, you can install a Docker environment using the [Docker Toolbox](https://www.docker.com/docker-toolbox) which
+will install Docker Client, Machine, Compose, Kitematic and VirtualBox.
 
-### OSX boot2docker quick start
+### OSX Docker Machine quick start
 
-If you're eager to get up to speed on OSX, below is a quickstart that
-installs boot2docker via the [Homebrew package
-manager](http://brew.sh/).
+If you're eager to get up to speed on OSX, install [Docker Toolbox](https://www.docker.com/docker-toolbox)to quickly install and setup a Docker environment on your computer. Docker Toolbox installs Docker Client, Docker Machine, Docker Compose, Docker Kitematic, and VirtualBox. Once Docker Toolbox has finished installing, use `docker-machine` to create a virtual machine that can run Docker. In this example, we will be creating a VM named `dev`.
 
 ```no-highlight
-brew install boot2docker
-
-boot2docker init
-boot2docker up
-
-$(boot2docker shellinit)
+$ docker-machine create --driver virtualbox dev
 ```
+
+Now that we created the VM for Docker to run on, we need to configure our shell so that Docker can access the newly created VM. You can do this by running the following command:
+
+```no-highlight
+$ eval "$(docker-machine env dev)"
+```
+
+Now you should have a working Docker environment!
+
+Note that this will only activate Docker in the current shell session. If you want to ensure that Docker runs on all your shells, run the following command to view your VM's environment variables and certificates:
+
+```no-highlight 
+$ docker-machine env dev
+export DOCKER_TLS_VERIFY="1"
+export DOCKER_HOST="tcp://192.168.99.101:2376"
+export DOCKER_CERT_PATH="/Users/mary/.docker/machine/machines/dev"
+export DOCKER_MACHINE_NAME="dev"
+# Run this command to configure your shell:
+# eval "$(docker-machine env dev)
+```
+
+Then take these three `exports` and add them to your `.profile`.
 
 ### Getting the CLI
 

--- a/content/learn/basics/the-wercker-cli.md
+++ b/content/learn/basics/the-wercker-cli.md
@@ -18,7 +18,7 @@ depending on your distribution and package manager. See Docker's
 instructions](https://docs.docker.com/installation/#installation) fore more information.
 
 If you are running Mac OSX, you can install a Docker environment using the [Docker Toolbox](https://www.docker.com/docker-toolbox) which
-will install Docker Client, Machine, Compose, Kitematic and VirtualBox.
+will install Docker Client, Machine, Compose, Kitematic, and VirtualBox.
 
 ### OSX Docker Machine quick start
 


### PR DESCRIPTION
docker has deprecated the `boot2docker` tool in favor of docker machine. this changes the quick start docs to use docker machine to set up a docker environment