### PR TITLE
Use unicode escape for bullet points.

### DIFF
--- a/docs-articles/index.css
+++ b/docs-articles/index.css
@@ -167,7 +167,7 @@ body.sidebar-open .docs-articles {
 
 .docs-articles > ul li:before,
 .docs-articles > ol li:before {
-  content: "• ";
+  content: "\2022 ";
   color: var(--color-blue_light);
 }
 


### PR DESCRIPTION
Hard to reproduce, but sometimes bullet points are rendered weird. Possibly due to s3 returning content-type headers without an encoding. Using utf8 escape codes in the :before content fixes it.