### PR TITLE
step "internal-watch" is actually "internal/watch"

### DIFF
--- a/content/quickstarts/building/golang.md
+++ b/content/quickstarts/building/golang.md
@@ -72,7 +72,7 @@ specified. You can read more about containers
 In the `dev` clause we define what we want to happen in our development
 pipeline, which in this case is just one step: `internal/watch`.
 
-`internal-watch` watches your files for changes, and if `reload` is set to
+`internal/watch` watches your files for changes, and if `reload` is set to
 `true` it restarts your app so your changes are reflected immediately. This is
 especially useful for when you're developing webapps, as we're doing now.
 

--- a/content/quickstarts/building/javascript.md
+++ b/content/quickstarts/building/javascript.md
@@ -63,7 +63,7 @@ community. You can read more about steps [here](/docs/steps/index.html)
 
 `npm-install` is a wercker step that, unsurprisingly, runs `npm-install`.
 
-`internal-watch` watches your files for changes, and if `reload` is set to
+`internal/watch` watches your files for changes, and if `reload` is set to
 `true` it restarts your app so your changes are reflected immediately. This is
 especially useful for when you're developing webapps, as we're doing now.
 

--- a/content/quickstarts/building/ruby.md
+++ b/content/quickstarts/building/ruby.md
@@ -95,12 +95,12 @@ dev:
 ```
 
 In the `dev` clause we define what we want to happen in our development
-pipeline, which in this case are two steps: `bundle-install` and `internal-watch`.
+pipeline, which in this case are two steps: `bundle-install` and `internal/watch`.
 These `steps` are pre-written bash scripts written by either wercker or the
 community. You can read more about steps
 [here](/docs/steps/index.html)
 
-`internal-watch` watches your files for changes, and if `reload` is set to
+`internal/watch` watches your files for changes, and if `reload` is set to
 `true` it restarts your app so your changes are reflected immediately. This is
 especially useful for when you're developing webapps, as we're doing now.
 


### PR DESCRIPTION
http://devcenter.wercker.com/docs/steps/internal-steps.html#internal-watch

I should've done an ack-grep when I made https://github.com/wercker/docs/pull/368