### PR TITLE
clarify different level envvars & ssh keys

### DIFF
--- a/content/docs/environment-variables/creating-env-vars.md
+++ b/content/docs/environment-variables/creating-env-vars.md
@@ -10,8 +10,11 @@ Environment variables include text fields and ssh keys.
 
 ### <a name="text-env-var" class="anchor"></a>Creating a text environment variable
 
+First choose where you want to create your environment variable: on the
+organization, on the application or on the pipeline.
+
 Creating a new environment variable is as simple as filling in a name, value and
-hitting Save. The next pipeline run you will trigger now has the environment variable
+hitting Add. The next pipeline run you will trigger now has the environment variable
 available in its pipeline.
 
 ![Form to create new environment variable](/images/creating-env-vars_1.png)
@@ -27,8 +30,8 @@ All environment variable that are available need to be used by adding a `$` char
 For instance a `SLACK_URL` environment variable  can be used in your
 wercker.yml as `$SLACK_URL`.
 
-Example how you to use a environment variable with our
-[Slack notify step](https://app.wercker.com/applications/54d4a6c742494161430000f5/tab/details).
+Example of how you to use a environment variable with our
+[Slack notify step](https://app.wercker.com/applications/54d4a6c742494161430000f5/tab/details):
 
 ```yaml
 build:
@@ -39,7 +42,7 @@ build:
             username: myamazingbotname
 ```
 
-### <a name="ssh-env-var" class="anchor"></a>Creating a SSH key pair
+### <a name="ssh-env-var" class="anchor"></a>Creating an SSH key pair
 environment variables
 
 ![+ Generate SSH Keys](/images/creating-env-vars_2.png)
@@ -56,4 +59,4 @@ you may want to name the variable `DEPLOY_KEY`. During the pipeline
 run you will now have two environment variables: `$DEPLOY_KEY_PRIVATE`
 and `$DEPLOY_KEY_PUBLIC`.
 
-
+[Read more on generaging ssh keys &rsaquo;](/docs/ssh-keys/generating-ssh-keys.html)

--- a/content/docs/environment-variables/index.md
+++ b/content/docs/environment-variables/index.md
@@ -5,22 +5,37 @@ information that is either unique for each server you want to deploy to or may
 be too sensitive to store in the repository. Wercker supports a number of ways
 to store and expose this data as environment variables.
 
-### Global environment variables
-
-There are variables which are `global`. Typically, these are used to store API
-tokens for after-steps such as slack, hipchat, campfire etc. These variables
-are called pipeline variables and can be set in the settings tab of your
-application.
-
 [Read more about creating env vars &rsaquo;](/docs/environment-variables/creating-env-vars.html)
 
-### Workfow environment variables
+### Organization-level environment variables
 
-The second set of variables are specific to
-[workflows](/docs/workflows/index.html), and can only be set directly on the
-Workflow. Typically, these are used to store information such as `hostnames`,
-`ssh-keys`, `passwords` and more.  These variables are called `Workflow
-variables`.
+When you have an organization you can create environment variables on that
+organization from the organization settings. These environment variables will
+be available to all projects and pipelines in that organization. These can be
+used to set some global settings that should apply to everything under and
+organization, such as an ssh key to fetch private Github repositories. Keep in
+mind that public projects under the organization will also have access to these
+variables.
+
+### Application-level environment variables
+
+The second set of variables are specific to the application. All runs under
+this application will receive these environment variables. This can be useful
+for setting AWS secrets, Docker credentials or anything else that several
+pipelines in the application might use.
+
+In the case of an identical name, an environment variable defined on an
+application will override an environment variable defined on the organization.
+
+### Pipeline-level environment variables
+
+The third set of variables are specific to pipelines in a
+[workflow](/docs/workflows/index.html). These are made available to each
+pipeline run. Typically, these are used to store information such as hostnames,
+ssh-keys, passwords and more. 
+
+The pipeline environment variable will override environment variables with the
+same name on the organization or the application.
 
 ### Available environment variables
 
@@ -34,5 +49,8 @@ not show all environment variables available during the pipeline run.
     code: |
         env
 ```
+
+Keep in mind that this will list all variables — including protected ones — so
+you might not want to do this on a public project.
 
 [See the complete list of available env vars &rsaquo;](/docs/environment-variables/available-env-vars.html)

--- a/content/docs/ssh-keys/generating-ssh-keys.md
+++ b/content/docs/ssh-keys/generating-ssh-keys.md
@@ -1,7 +1,7 @@
 ## Generating SSH Keys
 
 To generate an SSH key pair open the application settings, pipeline settings or
-organization settings and click the `+ Generate SSH key` link. From the
+organization settings and click the `+ Generate SSH keys` link. From the
 dialog you can choose a name for you SSH key and the number of bits to use to
 generate it. Wercker will generate the key for you in the background and create
 two environment variables.
@@ -18,7 +18,7 @@ copying the private key as an environment variable. The environment variable
 *must* end with `_PRIVATE`. For instance if you wanted to manually add a
 `BITBUCKET` ssh key create a new environment variable called
 `BITBUCKET_PRIVATE`. It is also strongly recommended that you mark the private
-key `protected`.
+key `Protected`.
 
 ![Manually added SSH key](/images/creating-ssh-keys_2.jpg)
 

--- a/content/docs/ssh-keys/using-ssh-keys.md
+++ b/content/docs/ssh-keys/using-ssh-keys.md
@@ -28,7 +28,8 @@ deploy:
 
 ### Add ssh key pipeline step
 
-Using this step in combination with an SSH key allows you to use that key for SSH operations, such as cloning a private repository:
+Using this step in combination with an SSH key allows you to use that key for
+SSH operations, such as cloning a private repository:
 
 ```yaml
 build:
@@ -36,6 +37,13 @@ build:
         - add-ssh-key:
             keyname: MYPACKAGE_KEY
 ```
+
+> Keep in mind that if your environment variables are `MYPACKAGE_KEY_PUBLIC`
+> and `MYPACKAGE_KEY_PRIVATE` the keyname should only be `MYPACKAGE_KEY`.
+
+As with environment variables if the same ssh key has been specified on an
+organization or application the lower level will override the higher level
+one (organization - application - pipeline).
 
 Now your SSH key can be used to clone private repositories during a pipeline run.
 This solution works as long as we clone via SSH (i.e. not using https).


### PR DESCRIPTION
We had some old naming regarding workflows in the docs, this clears that up.

- Clarifies how environment variables are overridden
- Clarifies the use of ssh keys
- Various small typos and fixes